### PR TITLE
update appium java client to version 7.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ libraryDependencies ++= Seq(
   //"org.scala-lang" % "scala-compiler" % scalaVersion.value,
   //"org.scala-lang" % "scala-library" % scalaVersion.value,
   //"org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  "io.appium" % "java-client" % "5.0.4",
+  "io.appium" % "java-client" % "7.0.0",
   "org.seleniumhq.selenium" % "selenium-java" % "2.53.1" % "test",
   //"io.selendroid" % "selendroid" % "0.16.0",
   "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.8.7",

--- a/src/main/scala/com/testerhome/appcrawler/driver/AppiumClient.scala
+++ b/src/main/scala/com/testerhome/appcrawler/driver/AppiumClient.scala
@@ -3,14 +3,17 @@ package com.testerhome.appcrawler.driver
 import java.awt.{BasicStroke, Color}
 import java.io.File
 import java.net.URL
-import java.time.Duration
-import javax.imageio.ImageIO
 
+import javax.imageio.ImageIO
 import com.testerhome.appcrawler.{AppCrawler, CommonLog, DataObject, URIElement}
 import com.testerhome.appcrawler._
 import io.appium.java_client.{AppiumDriver, TouchAction}
 import io.appium.java_client.android.AndroidDriver
 import io.appium.java_client.ios.IOSDriver
+import io.appium.java_client.touch.offset.ElementOption.element
+import io.appium.java_client.touch.offset.PointOption.point
+
+
 import org.apache.log4j.Level
 import org.openqa.selenium.{OutputType, Rectangle, TakesScreenshot, WebElement}
 import org.scalatest.selenium.WebBrowser
@@ -220,12 +223,12 @@ class AppiumClient extends CommonLog with WebBrowser with WebDriver{
     if(screenHeight<=0){
       getDeviceInfo()
     }
+
     retry(
       driver.performTouchAction(
         new TouchAction(driver)
-          .press((screenWidth * startX).toInt, (screenHeight * startY).toInt)
-          .moveTo((screenWidth * (endX-startX)).toInt, (screenHeight * (endY-startY)).toInt)
-          //.waitAction(Duration.ofSeconds(1))
+          .press(point((screenWidth * startX).toInt, (screenHeight * startY).toInt)).asInstanceOf[TouchAction[_]]
+          .moveTo(point((screenWidth * (endX-startX)).toInt, (screenHeight * (endY-startY)).toInt))
           .release()
       )
     )
@@ -275,12 +278,12 @@ class AppiumClient extends CommonLog with WebBrowser with WebDriver{
   }*/
 
   override def tap(): this.type = {
-    driver.performTouchAction(new TouchAction(driver).tap(currentElement))
+    driver.performTouchAction(new TouchAction(driver).tap(element(currentElement)))
     this
   }
 
   override def longTap(): this.type = {
-    driver.performTouchAction(new TouchAction(driver).longPress(currentElement))
+    driver.performTouchAction(new TouchAction(driver).longPress(element(currentElement)))
     this
   }
 


### PR DESCRIPTION
The version `7.0.0` can support some functions like `findElementById`,  on the contrary, the version `5.0.4` may cause error something like `Locator Strategy 'css selector' is not supported` 